### PR TITLE
fix: improve SQL query handling and infinite scrolling for query results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.2] - 2026-05-08
+
+### Fixed
+
+- **Query Results**:
+    - Fixed infinite scrolling in query results so additional rows load correctly when scrolling to the bottom.
+    - Corrected query result state handling so SQL-backed result tabs append newly loaded rows to the visible dataset.
+
 ## [2.1.0] - 2026-03-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pinkparquet",
-  "version": "2.0.5",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pinkparquet",
-      "version": "2.0.5",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinkparquet",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3689,7 +3689,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinkparquet"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "chrono",
  "hex",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinkparquet"
-version = "2.1.1"
+version = "2.1.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"
@@ -34,4 +34,3 @@ parquet = "57.1.0"
 chrono = "0.4"
 hex = "0.4"
 notify = "8"
-

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pink Parquet",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "identifier": "com.marek.pinkparquet",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/DataTable.svelte
+++ b/src/lib/components/DataTable.svelte
@@ -229,6 +229,16 @@
     return sort ? sort.ascending : null
   }
 
+  function shouldUseSqlQuery(session = dataStore.activeSession): boolean {
+    if (!session) return false
+
+    if (session.isQueryResult) {
+      return !!session.sqlQuery?.trim()
+    }
+
+    return dataStore.isSqlTabActive && dataStore.isQueryMode
+  }
+
 
   async function reloadData() {
     const session = dataStore.activeSession
@@ -239,7 +249,7 @@
       tableContainer.scrollTop = 0
     }
 
-    const isQuery = dataStore.isSqlTabActive && dataStore.isQueryMode
+    const isQuery = shouldUseSqlQuery(session)
     dataStore.setLoading(true, undefined, isQuery)
 
     try {
@@ -277,7 +287,7 @@
     const session = dataStore.activeSession
     if (isLoadingMore || !hasMoreRows || !session) return
 
-    const isQuery = dataStore.isSqlTabActive && dataStore.isQueryMode
+    const isQuery = shouldUseSqlQuery(session)
     dataStore.setLoadingMore(true, undefined, isQuery)
 
     try {

--- a/src/lib/stores/dataStore.svelte.ts
+++ b/src/lib/stores/dataStore.svelte.ts
@@ -65,6 +65,11 @@ let sqlEditorHeight = $state<number>(0)
 const queryListeners = new Set<() => void>()
 
 export const dataStore = {
+    usesSqlStorage(session?: FileSession | null, isSqlOverride?: boolean) {
+        if (!session) return false
+        if (session.isQueryResult) return false
+        return isSqlOverride !== undefined ? isSqlOverride : isSqlTabActive
+    },
     get sessions() {
         return sessions
     },
@@ -116,7 +121,7 @@ export const dataStore = {
     get loading() {
         const session = this.activeSession
         if (!session) return false
-        return isSqlTabActive ? session.loadingQuery : session.loadingRaw
+        return this.usesSqlStorage(session) ? session.loadingQuery : session.loadingRaw
     },
     get error() {
         return this.activeSession?.error || null
@@ -124,7 +129,9 @@ export const dataStore = {
     get loadingMore() {
         const session = this.activeSession
         if (!session) return false
-        return isSqlTabActive ? session.loadingMoreQuery : session.loadingMoreRaw
+        return this.usesSqlStorage(session)
+            ? session.loadingMoreQuery
+            : session.loadingMoreRaw
     },
     get hasData() {
         return sessions.length > 0
@@ -178,7 +185,11 @@ export const dataStore = {
     get metadata() {
         const session = this.activeSession
         if (!session) return null
-        return (this.isSqlTabActive ? session.queryData?.metadata : session.rawData?.metadata) || null
+        return (
+            this.usesSqlStorage(session)
+                ? session.queryData?.metadata
+                : session.rawData?.metadata
+        ) || null
     },
     get totalRows() {
         const d = this.data
@@ -485,8 +496,7 @@ export const dataStore = {
             ? sessions.find((s) => s.id === sessionId)
             : this.activeSession
 
-        const effectiveIsSql =
-            isSqlResult !== undefined ? isSqlResult : isSqlTabActive
+        const effectiveIsSql = this.usesSqlStorage(session, isSqlResult)
 
         if (session) {
             if (effectiveIsSql) {
@@ -538,7 +548,7 @@ export const dataStore = {
             ? sessions.find((s) => s.id === sessionId)
             : this.activeSession
 
-        const effectiveIsSql = isSql !== undefined ? isSql : this.isSqlTabActive
+        const effectiveIsSql = this.usesSqlStorage(session, isSql)
 
         if (session) {
             if (effectiveIsSql && session.queryData) {
@@ -565,7 +575,7 @@ export const dataStore = {
             ? sessions.find((s) => s.id === sessionId)
             : this.activeSession
         if (session) {
-            const effectiveIsSql = isSql !== undefined ? isSql : this.isSqlTabActive
+            const effectiveIsSql = this.usesSqlStorage(session, isSql)
             if (effectiveIsSql) {
                 session.loadingQuery = isLoading
             } else {
@@ -580,7 +590,7 @@ export const dataStore = {
             ? sessions.find((s) => s.id === sessionId)
             : this.activeSession
         if (session) {
-            const effectiveIsSql = isSql !== undefined ? isSql : this.isSqlTabActive
+            const effectiveIsSql = this.usesSqlStorage(session, isSql)
             if (effectiveIsSql) {
                 session.loadingMoreQuery = isLoading
             } else {


### PR DESCRIPTION
- Refactor `shouldUseSqlQuery` logic to determine query state more reliably.
- Fix query result state management to ensure seamless row appending during scrolling.
- Bump version to 2.1.2 with associated changelog updates.